### PR TITLE
update mud.h

### DIFF
--- a/mud_src/mud.h
+++ b/mud_src/mud.h
@@ -183,10 +183,10 @@ typedef UINT32                  BOOL;
 /*
  *  c_utils.h,  Defines for C utilities
  */
-#if defined(vms) || defined(_WIN32)
+#if defined(vms) || defined(__MSDOS__) || defined(_WIN32)
 #define bcopy( b1, b2, len )		memcpy(b2,b1,len)
 #define bzero( b, len )			memset(b,(char)0,len)
-#endif /* vms || _WIN32 */
+#endif /* vms || __MSDOS__ || _WIN32 */
 #ifndef _C_UTILS_H_   /* conflict with c_utils.h */
 #define _max( a, b )			( ( (a) > (b) ) ? (a) : (b) )
 #define _min( a, b )			( ( (a) < (b) ) ? (a) : (b) )
@@ -199,11 +199,10 @@ typedef UINT32                  BOOL;
 #define _roundUp( n, r )		( (r) * (int)( ((n)+(r)-1) / (r) ) )
 
 #define zalloc( n )			memset((void*)malloc(n),0,n)
-#if defined(vms) || (defined(mips)&&!defined(__sgi)) || (defined(_WIN32)&&defined(__STDC__))
+#if defined(vms) || (defined(mips)&&!defined(__sgi)) || (defined(__MSDOS__)&&defined(__STDC__))
 #define strdup( s )			strcpy((char*)malloc(strlen(s)+1),s)
 #endif /* vms || mips&&!sgi */
 /*#endif */
-typedef int (*MUD_PROC)();
 
 typedef enum {
     MUD_ENCODE = 0,
@@ -213,6 +212,8 @@ typedef enum {
     MUD_SHOW = 4,
     MUD_HEADS = 5
 } MUD_OPT;
+
+typedef int (*MUD_PROC)(MUD_OPT, void *p1, void *p2);
 
 typedef enum {
     MUD_ONE = 1,
@@ -426,7 +427,7 @@ typedef struct {
 #define MUD_instanceID( pM )	(((MUD_SEC*)pM)->core.instanceID)
 
 
-#if defined(_WIN32) || defined(__i386__) || defined(__i586__) || defined(__i686__) || defined(vax) || defined(__alpha) || defined(__amd64) || defined(__arm64) || (defined(__mips)&&!defined(__sgi))
+#if defined(__MSDOS__) || defined(_WIN32) || defined(__i386__) || defined(__i586__) || defined(__i686__) || defined(vax) || defined(__alpha) || defined(__amd64) || defined(__arm64) || (defined(__mips)&&!defined(__sgi))
 #define MUD_LITTLE_ENDIAN 1
 #else
 #define MUD_BIG_ENDIAN 1


### PR DESCRIPTION
Update `mud.h` to appease modern compilers (e.g., gcc 15.1.1)

Changes "plucked" from a recent update to `musrfit` - see: https://bitbucket.org/muonspin/musrfit/commits/6e60013037c73894af9e10d62149dce8f9558199